### PR TITLE
Remove multiple charset rules

### DIFF
--- a/src/test/java/com/google/common/css/compiler/passes/CreateStandardAtRuleNodesTest.java
+++ b/src/test/java/com/google/common/css/compiler/passes/CreateStandardAtRuleNodesTest.java
@@ -395,6 +395,20 @@ class CreateStandardAtRuleNodesTest extends PassesTestBase {
     }
 
     @Test
+    void testMultipleCharsetWarning() throws Exception {
+        CssTree t = parseAndRun("@charset \"UTF-8\"; @charset \"iso-8859-15\";",
+                CreateStandardAtRuleNodes.IGNORED_CHARSET_WARNING_MESSAGE);
+        assertWithMessage("This pass should remove superfluous charset nodes.")
+                .that(
+                        SExprPrinter.print(false, false, t))
+                .isEqualTo(
+                        "(com.google.common.css.compiler.ast.CssRootNode " +
+                                "(com.google.common.css.compiler.ast.CssImportBlockNode)" +
+                                "(com.google.common.css.compiler.ast.CssBlockNode " +
+                                "(com.google.common.css.compiler.ast.CssCharSetNode)))");
+    }
+
+    @Test
     void testMonochrome() throws Exception {
         parseAndRun(
                 "@media (monochrome) {\n"

--- a/src/test/java/com/google/common/css/compiler/passes/CreateStandardAtRuleNodesTest.java
+++ b/src/test/java/com/google/common/css/compiler/passes/CreateStandardAtRuleNodesTest.java
@@ -395,6 +395,71 @@ class CreateStandardAtRuleNodesTest extends PassesTestBase {
     }
 
     @Test
+    void testCreateCharSetNodeInvalidCharacterBefore() throws GssParserException {
+        CssTree t = parseAndRun("a,i{} @charset \"UTF-8\"; foo,hr,.bar,i{} ",
+                CreateStandardAtRuleNodes.CHARSET_ERROR_CHAR_BEFORE_MESSAGE);
+        assertWithMessage("This pass should find errors.")
+                .that(
+                        SExprPrinter.print(false, false, t))
+                .isEqualTo(
+                        "(com.google.common.css.compiler.ast.CssRootNode " +
+                                "(com.google.common.css.compiler.ast.CssImportBlockNode)" +
+                                "(com.google.common.css.compiler.ast.CssBlockNode " +
+                                "(com.google.common.css.compiler.ast.CssRulesetNode " +
+                                "(com.google.common.css.compiler.ast.CssSelectorListNode " +
+                                "(com.google.common.css.compiler.ast.CssSelectorNode)" +
+                                "(com.google.common.css.compiler.ast.CssSelectorNode))" +
+                                "(com.google.common.css.compiler.ast.CssDeclarationBlockNode))" +
+                                "(com.google.common.css.compiler.ast.CssRulesetNode " +
+                                "(com.google.common.css.compiler.ast.CssSelectorListNode " +
+                                "(com.google.common.css.compiler.ast.CssSelectorNode)" +
+                                "(com.google.common.css.compiler.ast.CssSelectorNode)" +
+                                "(com.google.common.css.compiler.ast.CssSelectorNode " +
+                                "(com.google.common.css.compiler.ast.CssClassSelectorNode))" +
+                                "(com.google.common.css.compiler.ast.CssSelectorNode))" +
+                                "(com.google.common.css.compiler.ast.CssDeclarationBlockNode))))");
+    }
+
+    @Test
+    void testCreateCharSetNodeInvalidWrongQuotes() throws GssParserException {
+        CssTree t = parseAndRun("@charset 'UTF-8';",
+                CreateStandardAtRuleNodes.INVALID_PARAMETERS_ERROR_MESSAGE);
+        assertWithMessage("This pass should find errors.")
+                .that(
+                        SExprPrinter.print(false, false, t))
+                .isEqualTo(
+                        "(com.google.common.css.compiler.ast.CssRootNode " +
+                                "(com.google.common.css.compiler.ast.CssImportBlockNode)" +
+                                "(com.google.common.css.compiler.ast.CssBlockNode))");
+    }
+
+    @Test
+    void testCreateCharSetNodeInvalidMissingQuotes() throws GssParserException {
+        CssTree t = parseAndRun("@charset UTF-8;",
+                CreateStandardAtRuleNodes.INVALID_PARAMETERS_ERROR_MESSAGE);
+        assertWithMessage("This pass should find an error.")
+                .that(
+                        SExprPrinter.print(false, false, t))
+                .isEqualTo(
+                        "(com.google.common.css.compiler.ast.CssRootNode " +
+                                "(com.google.common.css.compiler.ast.CssImportBlockNode)" +
+                                "(com.google.common.css.compiler.ast.CssBlockNode))");
+    }
+
+    @Test
+    void testCreateCharSetNodeInvalidMissingParameter() throws GssParserException {
+        CssTree t = parseAndRun("@charset;",
+                CreateStandardAtRuleNodes.INVALID_PARAMETERS_ERROR_MESSAGE);
+        assertWithMessage("This pass should find an error.")
+                .that(
+                        SExprPrinter.print(false, false, t))
+                .isEqualTo(
+                        "(com.google.common.css.compiler.ast.CssRootNode " +
+                                "(com.google.common.css.compiler.ast.CssImportBlockNode)" +
+                                "(com.google.common.css.compiler.ast.CssBlockNode))");
+    }
+
+    @Test
     void testMultipleCharsetWarning() throws Exception {
         CssTree t = parseAndRun("@charset \"UTF-8\"; @charset \"iso-8859-15\";",
                 CreateStandardAtRuleNodes.IGNORED_CHARSET_WARNING_MESSAGE);

--- a/src/test/java/com/google/common/css/compiler/passes/TemplateCompactPrinterTest.java
+++ b/src/test/java/com/google/common/css/compiler/passes/TemplateCompactPrinterTest.java
@@ -40,6 +40,7 @@ class TemplateCompactPrinterTest extends AbstractCompactPrinterTest {
     protected void setupTestTree() {
         String sourceCode =
                 "@charset \"UTF-8\"; "
+                        + "@charset \"iso-8859-15\"; "
                         + "foo,hr,.bar,i{} "
                         + "a,i{} "
                         + "b,hr{} "
@@ -93,6 +94,9 @@ class TemplateCompactPrinterTest extends AbstractCompactPrinterTest {
                                 + "@charset\"UTF-8\""
                                 + rE
                                 + R_S
+                                + "@charset\"iso-8859-15\""
+                                + rE
+                                + R_S
                                 + "foo{}"
                                 + rE
                                 + R_S
@@ -137,6 +141,9 @@ class TemplateCompactPrinterTest extends AbstractCompactPrinterTest {
                                 + "@charset\"UTF-8\""
                                 + rE
                                 + R_S
+                                + "@charset\"iso-8859-15\""
+                                + rE
+                                + R_S
                                 + ".bar{}"
                                 + rE
                                 + R_S
@@ -164,7 +171,7 @@ class TemplateCompactPrinterTest extends AbstractCompactPrinterTest {
 
         assertThat(printer.getCompactPrintedString())
                 .isEqualTo(
-                        R_S + "@charset\"UTF-8\"" + rE + R_S + "hr,i{}" + rE + R_S + "i{}" + rE + R_S + "hr{}" + rE + R_S + "i,hr{}" + rE + R_S
+                        R_S + "@charset\"UTF-8\"" + rE + R_S + "@charset\"iso-8859-15\"" + rE + R_S + "hr,i{}" + rE + R_S + "i{}" + rE + R_S + "hr{}" + rE + R_S + "i,hr{}" + rE + R_S
                                 + "a i{}" + rE + R_S + "a+i{}" + rE);
     }
 

--- a/src/test/java/com/google/common/css/compiler/passes/TemplateCompactPrinterTest.java
+++ b/src/test/java/com/google/common/css/compiler/passes/TemplateCompactPrinterTest.java
@@ -94,9 +94,6 @@ class TemplateCompactPrinterTest extends AbstractCompactPrinterTest {
                                 + "@charset\"UTF-8\""
                                 + rE
                                 + R_S
-                                + "@charset\"iso-8859-15\""
-                                + rE
-                                + R_S
                                 + "foo{}"
                                 + rE
                                 + R_S
@@ -141,9 +138,6 @@ class TemplateCompactPrinterTest extends AbstractCompactPrinterTest {
                                 + "@charset\"UTF-8\""
                                 + rE
                                 + R_S
-                                + "@charset\"iso-8859-15\""
-                                + rE
-                                + R_S
                                 + ".bar{}"
                                 + rE
                                 + R_S
@@ -171,7 +165,7 @@ class TemplateCompactPrinterTest extends AbstractCompactPrinterTest {
 
         assertThat(printer.getCompactPrintedString())
                 .isEqualTo(
-                        R_S + "@charset\"UTF-8\"" + rE + R_S + "@charset\"iso-8859-15\"" + rE + R_S + "hr,i{}" + rE + R_S + "i{}" + rE + R_S + "hr{}" + rE + R_S + "i,hr{}" + rE + R_S
+                        R_S + "@charset\"UTF-8\"" + rE + R_S + "hr,i{}" + rE + R_S + "i{}" + rE + R_S + "hr{}" + rE + R_S + "i,hr{}" + rE + R_S
                                 + "a i{}" + rE + R_S + "a+i{}" + rE);
     }
 


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/CSS/@charset only the first occurrence of the charset rule is adhered to.
So following instances can be removed without changing semantics.